### PR TITLE
Use prisma singleton

### DIFF
--- a/prisma/client.js
+++ b/prisma/client.js
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/prisma/client.js
+++ b/prisma/client.js
@@ -1,5 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 
-const prisma = new PrismaClient();
+if (global.prisma == null) {
+  global.prisma = new PrismaClient();
+}
 
-export default prisma;
+export default global.prisma;

--- a/src/repositories/todo-item.repository.js
+++ b/src/repositories/todo-item.repository.js
@@ -1,6 +1,4 @@
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '../../prisma/client';
 
 /**
  * Get all of the existing todos
@@ -14,8 +12,6 @@ export async function findAll() {
     return allItems;
   } catch (e) {
     console.log(`Err: ${e}`)
-  } finally {
-    await prisma.$disconnect();
   }
 }
 
@@ -34,8 +30,6 @@ export async function findOne({ id }) {
     return todoItem;
   } catch (e) {
     console.log(`Err: ${e}`)
-  } finally {
-    await prisma.$disconnect();
   }
 }
 
@@ -54,8 +48,6 @@ export async function deleteTodo({ id }) {
     return todo;
   } catch (e) {
     console.log(`Err: ${e}`)
-  } finally {
-    await prisma.$disconnect();
   }
 }
 
@@ -89,8 +81,6 @@ export async function createTodoItem({
     console.log(`Err: ${e}`);
 
     return null;
-  } finally {
-    await prisma.$disconnect();
   }
 }
 
@@ -126,7 +116,5 @@ export async function updateTodoItem({
     console.log(`Err: ${e}`);
 
     return null;
-  } finally {
-    await prisma.$disconnect();
   }
 }


### PR DESCRIPTION
Previously, a new `PrismaClient()` may have been created with each query. A client singleton has been created and imported into the repository for multiple queries. Ideally, this limits the number of connections created.